### PR TITLE
Updated for Forge 1.15.2, no other changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ minecraft {
     // stable_#            Stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
-    mappings channel: 'snapshot', version: '20190719-1.14.3'
+    mappings channel: 'snapshot', version: '20200514-1.15.1'
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 
     // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
@@ -89,7 +89,7 @@ dependencies {
     // Specify the version of Minecraft to use, If this is any group other then 'net.minecraft' it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.14.4-28.0.13'
+    minecraft 'net.minecraftforge:forge:1.15.2-31.2.31'
 
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"

--- a/src/main/java/com/alexanderstrada/practicaltools/items/GreataxeItem.java
+++ b/src/main/java/com/alexanderstrada/practicaltools/items/GreataxeItem.java
@@ -25,8 +25,8 @@ import net.minecraft.tags.BlockTags;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.gameevent.TickEvent;
 
 import java.util.ArrayList;
 import java.util.Set;

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -43,6 +43,6 @@ GitHub: https://github.com/astradamus
 [[dependencies.practicaltools]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.14.4]"
+    versionRange="[1.15.2]"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
Only "real" change was updating where `TickEvent.WorldTickEvent` is imported from.

Other than that I made the bare minimum changes required to make it run in 1.15 (i.e. updating Forge + dep versions). Didn't change the mod version number because I didn't want to presume how you handle numbering.